### PR TITLE
Fix boxen version of puppet-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # Go Puppet Module for Boxen
 
-[![Build Status](https://travis-ci.org/boxen/puppet-go.png?branch=master)](https://travis-ci.org/boxen/puppet-go)
 
 ## Usage
 
 ```puppet
 include go
 
-go::version { '1.1.1': }
+go::version { '1.5.2': }
 
-include go::1_1
+include go::1_5_2
 
 go::local { '/path/to/whatever':
-  version => '1.1.1'
+  version => '1.5.2'
 }
 ```
 

--- a/manifests/1_5_2.pp
+++ b/manifests/1_5_2.pp
@@ -1,0 +1,5 @@
+# Public: Install Go 1.5_2
+
+class go::1_5_2 {
+  go::version { '1.5_2': }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,6 @@ class go::params {
 
   $auto_switch  = true
 
-  $chgo_version = 'v0.1.1'
-  $chgo_source  = 'wfarr/chgo'
+  $chgo_version = 'v0.1.7'
+  $chgo_source  = 'jbcpollak/chgo'
 }

--- a/spec/classes/go__global_spec.rb
+++ b/spec/classes/go__global_spec.rb
@@ -4,16 +4,16 @@ describe "go::global" do
   let(:facts) { default_test_facts }
   let(:params) do
     {
-      :version => "1.1.1"
+      :version => "1.5.2"
     }
   end
 
   it do
     should include_class("go")
-    should include_class("go::1_1_1")
+    should include_class("go::1_5_2")
 
     should contain_file("/test/boxen/chgo/version").with({
-      :content => "1.1.1\n",
+      :content => "1.5.2\n",
     })
   end
 end

--- a/spec/classes/go_spec.rb
+++ b/spec/classes/go_spec.rb
@@ -12,8 +12,8 @@ describe "go" do
     should contain_boxen__env_script("go")
 
     should contain_repository("/test/boxen/chgo").with({
-      :ensure => "v0.1.0",
-      :source => "wfarr/chgo",
+      :ensure => "v0.1.7",
+      :source => "jbcpollak/chgo",
       :user   => "testuser"
     })
   end

--- a/spec/defines/go__local_spec.rb
+++ b/spec/defines/go__local_spec.rb
@@ -4,7 +4,7 @@ describe "go::local" do
   let(:default_params) do
     {
       :ensure  => "present",
-      :version => "1.1.1"
+      :version => "1.5.2"
     }
   end
 
@@ -13,11 +13,11 @@ describe "go::local" do
   let(:params) { default_params }
 
   it do
-    should include_class("go::1_1_1")
+    should include_class("go::1_5_2")
 
     should contain_file("/path/to/wherever/.go-version").with({
       :ensure  => "present",
-      :content => "1.1.1\n",
+      :content => "1.5.2\n",
       :replace => true
     })
   end
@@ -26,7 +26,7 @@ describe "go::local" do
     let(:params) { default_params.merge(:ensure => "absent") }
 
     it do
-      should_not include_class("go::1_1_1")
+      should_not include_class("go::1_5_2")
 
       should contain_file("/path/to/wherever/.go-version").with({
         :ensure => "absent"


### PR DESCRIPTION
- Change to jbcpollak/chgo to fix download URL and path
- Add version 1.5.2
